### PR TITLE
[FEATURE] Namespaces and exceptions

### DIFF
--- a/requirements/test-py2.txt
+++ b/requirements/test-py2.txt
@@ -1,0 +1,2 @@
+mock>=2.0.0
+-r main.txt

--- a/scout/test_scout.py
+++ b/scout/test_scout.py
@@ -1,17 +1,40 @@
+import logging
+import os
+import platform 
 import requests
 import unittest
 import uuid
-import os
 
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    # In Python 2, "mock" is an addon
+    import mock
+
 from .scout import Scout
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test_scout %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+# Uncomment if you're trying to debug the tests.
+# logging.getLogger("root").setLevel(logging.DEBUG)
+# logging.getLogger("datawire.scout").setLevel(logging.DEBUG)
+
+logging.info("Running under Python %s" % platform.python_version())
 
 install_id = str(uuid.uuid4())
 
 PLUGIN_UUID = str(uuid.uuid4())
 
-def install_id_plugin(scout, app):
-    return { "install_id": PLUGIN_UUID, "new_install": True, "swallow_speed": 42 }
+def install_id_plugin(scout, app, hello="FAILED"):
+    return { "install_id": PLUGIN_UUID,
+             "new_install": True,
+             "swallow_speed": 42,
+             "hello": hello }
 
 # This method will be used by the mock to replace requests.get
 def mocked_requests_post(*args, **kwargs):
@@ -20,18 +43,25 @@ def mocked_requests_post(*args, **kwargs):
     latest_version = '0.2.0'
 
     class MockResponse:
-        def __init__(self, json_data, status_code):
+        def __init__(self, json_data, status_code, text=None):
             self.json_data = json_data
             self.status_code = status_code
+            self.text = text or "<empty>"
 
         def json(self):
             return self.json_data
 
     app = kwargs["json"]["application"]
-    if app not in apps:
-        return MockResponse(None, 404)
 
-    return MockResponse({"latest_version": latest_version}, 200)
+    mockresp = MockResponse({"latest_version": latest_version}, 200)
+
+    if app not in apps:
+        mockresp = MockResponse(None, 404, "Application not found!")
+
+    logging.debug("MR: %d (%s) %s" % 
+                  (mockresp.status_code, mockresp.text, mockresp.json_data))
+
+    return mockresp
 
 
 class ScoutTestCase(unittest.TestCase):
@@ -65,6 +95,7 @@ class ScoutTestCase(unittest.TestCase):
         scout = Scout(app="unknown", version="0.1.0", install_id=install_id)
         resp = scout.report()
 
+        logging.debug("SR: %s" % resp)
         self.assertEqual(resp, {"latest_version": "0.1.0"})
 
     @mock.patch('requests.post', side_effect=mocked_requests_post)
@@ -82,11 +113,13 @@ class ScoutTestCase(unittest.TestCase):
 
         """Scout install-id plugin should set the install_id and requisite metadata."""
 
-        scout = Scout(app="foshizzolator", version="0.1.0", id_plugin=install_id_plugin)
+        scout = Scout(app="foshizzolator", version="0.1.0", 
+                      id_plugin=install_id_plugin, id_plugin_args={ "hello": "world" })
 
         self.assertEqual(scout.install_id, PLUGIN_UUID)
         self.assertEqual(scout.metadata["new_install"], True)
         self.assertEqual(scout.metadata["swallow_speed"], 42)
+        self.assertEqual(scout.metadata["hello"], "world")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,12 @@ deps =
 commands =
     python -m unittest
 
+[testenv:py2]
+deps =
+    -rrequirements/test-py2.txt
+commands =
+    python -m unittest scout.test_scout
+
 [testenv:linters]
 deps =
     - rrequirements.txt


### PR DESCRIPTION
Support Kube namespaces by allowing the Scout's creator to pass arguments to the `id_plugin`.

Be much, much more careful about exceptions when using requests, so that Scout applications can ride through connectivity issues or bad DNS names or whatnot.
